### PR TITLE
Fixes #3: calling start without parameters now works on Chrome.

### DIFF
--- a/DCBias.js
+++ b/DCBias.js
@@ -1,7 +1,7 @@
 (function() {
-	
+
 	function DCBias(context) {
-		
+
 		var output = context.createGain();
 		var buffer = context.createBuffer(1, 1, context.sampleRate);
 		var bufferSource = null;
@@ -9,6 +9,7 @@
 		buffer.getChannelData(0)[0] = 1.0;
 
 		output.start = function(when) {
+			when = typeof(when) === 'undefined' ? context.currentTime : when
 			bufferSource = context.createBufferSource();
 			bufferSource.buffer = buffer;
 			bufferSource.loop = true;
@@ -23,13 +24,13 @@
 			}
 			bufferSource = null;
 		};
-		
+
 		return output;
 
 	}
 
 	//
-	
+
 	if(typeof module !== 'undefined' && module.exports) {
 		module.exports = DCBias;
 	} else {
@@ -37,4 +38,3 @@
 	}
 
 }).call(this);
-

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "openmusic-dcbias",
+  "version": "1.2.0",
   "description": "A DCBias node for introducing a fixed-value signal in your audio graph",
   "main": "DCBias.js",
   "scripts": {
     "test": "echo \"Tests still not implemented\" && exit 0",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/openmusic/dcbias",
   "dependencies": {},
   "devDependencies": {
-    "openmusic-oscilloscope": "^1.0.0",
-    "semantic-release": "^4.3.4"
+    "openmusic-oscilloscope": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A DCBias node for introducing a fixed-value signal in your audio graph",
   "main": "DCBias.js",
   "scripts": {
-    "test": "echo \"Tests still not implemented\" && exit 0",
+    "test": "echo \"Tests still not implemented\" && exit 0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With this change, when calling start without parameters, it assumes when is current time.
